### PR TITLE
Reduce tool crosshair length to 2

### DIFF
--- a/addons/sprite_painter/src/editing_tools/tool_pencil.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_pencil.gd
@@ -78,7 +78,7 @@ func draw_preview(image_view : CanvasItem, mouse_position : Vector2i):
 		for x in drawing_positions:
 			image_view.draw_rect(Rect2(x, Vector2.ONE), drawing_color)
 
-	image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 32)).abs(), crosshair_color)
-	image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -32)).abs(), crosshair_color)
-	image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(32, 1)).abs(), crosshair_color)
-	image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-32, 1)).abs(), crosshair_color)
+	image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 2)).abs(), crosshair_color)
+	image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -2)).abs(), crosshair_color)
+	image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(2, 1)).abs(), crosshair_color)
+	image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-2, 1)).abs(), crosshair_color)

--- a/addons/sprite_painter/src/editing_tools/tool_select.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_select.gd
@@ -211,10 +211,10 @@ func draw_preview(image_view : CanvasItem, mouse_position : Vector2i):
 
 		return
 
-	image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 32)).abs(), preview_color)
-	image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -32)).abs(), preview_color)
-	image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(32, 1)).abs(), preview_color)
-	image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-32, 1)).abs(), preview_color)
+	image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 2)).abs(), preview_color)
+	image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -2)).abs(), preview_color)
+	image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(2, 1)).abs(), preview_color)
+	image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-2, 1)).abs(), preview_color)
 
 
 func draw_selection_preview(image_view : CanvasItem, mouse_position : Vector2i):

--- a/addons/sprite_painter/src/editing_tools/tool_shape.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_shape.gd
@@ -151,7 +151,7 @@ func draw_shader_preview(image_view : CanvasItem, mouse_position : Vector2i):
 
 func draw_preview(image_view : CanvasItem, mouse_position : Vector2i):
 	if !drawing:
-		image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 32)).abs(), crosshair_color)
-		image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -32)).abs(), crosshair_color)
-		image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(32, 1)).abs(), crosshair_color)
-		image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-32, 1)).abs(), crosshair_color)
+		image_view.draw_rect(Rect2i(mouse_position + Vector2i(0, 4), Vector2(1, 2)).abs(), crosshair_color)
+		image_view.draw_rect(Rect2i(mouse_position - Vector2i(0, 3), Vector2(1, -2)).abs(), crosshair_color)
+		image_view.draw_rect(Rect2i(mouse_position + Vector2i(4, 0), Vector2(2, 1)).abs(), crosshair_color)
+		image_view.draw_rect(Rect2i(mouse_position - Vector2i(3, 0), Vector2(-2, 1)).abs(), crosshair_color)


### PR DESCRIPTION
Replaces this:
![image](https://user-images.githubusercontent.com/118695973/233256577-a2c6c4c6-bea8-4e7a-a992-105d38b4d316.png)

With this:
![image](https://user-images.githubusercontent.com/118695973/233257144-0788bd12-d64f-46f9-a65e-261164ba95fb.png)

To be consistent with the circle crosshair type, and overall much less distracting.