### PR TITLE
Update tool_brush.gd add min brush size

### DIFF
--- a/addons/sprite_painter/src/editing_tools/tool_brush.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_brush.gd
@@ -178,7 +178,7 @@ func stroke(stroke_start, stroke_end, pressure):
 
 func paint(on_image, stroke_start, stroke_end, chunk_position, pressure):
 	var unsolid_radius = (brushsize * 0.5) * (1.0 - hardness)
-	var radius = max((brushsize * 0.5) * (pressure if pen_flags[0] else 1.0),(brushminsize * 0.5))
+	var radius = remap(brushsize * 0.5 * (pressure if pen_flags[0] else 1.0), 0.0, brushsize * 0.5, brushminsize * 0.5, brushsize * 0.5)
 	var solid_radius = radius - unsolid_radius
 
 	var color : Color

--- a/addons/sprite_painter/src/editing_tools/tool_brush.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_brush.gd
@@ -175,13 +175,10 @@ func stroke(stroke_start, stroke_end, pressure):
 				pressure
 			)
 
-#########################################################################################
+
 func paint(on_image, stroke_start, stroke_end, chunk_position, pressure):
 	var unsolid_radius = (brushsize * 0.5) * (1.0 - hardness)
 	var radius = max((brushsize * 0.5) * (pressure if pen_flags[0] else 1.0),(brushminsize * 0.5))
-	#print(pressure)
-	#print(radius)
-	#print(brushminsize * 0.5)
 	var solid_radius = radius - unsolid_radius
 
 	var color : Color

--- a/addons/sprite_painter/src/editing_tools/tool_brush.gd
+++ b/addons/sprite_painter/src/editing_tools/tool_brush.gd
@@ -12,9 +12,11 @@ enum {
 @export_enum("Draw", "Erase", "Clone", "Shading", "Normal Map") var brush_type := 0
 @export var chunk_size := Vector2i(256, 256)
 @export var max_brush_size := 150
+@export var max_brush_min_size := 150
 @export var crosshair_color := Color(0.5, 0.5, 0.5, 0.75)
 
 var brushsize := 5
+var brushminsize := 5
 var brush_offset := Vector2(0.5, 0.5)
 var hardness := 1.0
 var opacity := 1.0
@@ -37,6 +39,13 @@ func _ready():
 			brush_offset = Vector2(0.5, 0.5) * float(int(x) % 2),
 		TOOL_PROP_INT,
 		[1, max_brush_size],
+		true
+	)
+	add_property("Min Size", brushminsize,
+		func (x):
+		brushminsize = x,
+		TOOL_PROP_INT,
+		[1, max_brush_min_size],
 		true
 	)
 	add_property("Hardness", hardness * 100,
@@ -166,10 +175,13 @@ func stroke(stroke_start, stroke_end, pressure):
 				pressure
 			)
 
-
+#########################################################################################
 func paint(on_image, stroke_start, stroke_end, chunk_position, pressure):
 	var unsolid_radius = (brushsize * 0.5) * (1.0 - hardness)
-	var radius = (brushsize * 0.5) * (pressure if pen_flags[0] else 1.0)
+	var radius = max((brushsize * 0.5) * (pressure if pen_flags[0] else 1.0),(brushminsize * 0.5))
+	#print(pressure)
+	#print(radius)
+	#print(brushminsize * 0.5)
 	var solid_radius = radius - unsolid_radius
 
 	var color : Color


### PR DESCRIPTION
Fixes strange brush behavior when drawing from a graphics tablet when the pressure on the stylus is low enough that the actual brush size is less than 1 pixel

We're talking about this strange brush behavior:
![4f03ca066d5710a2](https://github.com/don-tnowe/godot-sprite-painter/assets/59219907/12db9ab8-d737-48ed-bc49-497259690640)

Adds a new setting for the brush and eraser tools:
![изображение](https://github.com/don-tnowe/godot-sprite-painter/assets/59219907/5be8decb-4be8-4e84-b471-91b3c965e4ab)

Known "bugs":
"Min Size" - not limited by the maximum threshold equal to "Size"
It follows from this that if “Min Size” is greater than “Size”, then “Min Size” will have priority.